### PR TITLE
AUT-15: Enable external link check for 4xx/5xx

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -13,9 +13,11 @@ after_build do |builder|
   begin
     HTMLProofer.check_directory(config[:build_dir],
       { :assume_extension => true,
-        :disable_external => true,
         :allow_hash_href => true,
         :empty_alt_ignore => true,
+        :file_ignore => [
+            /search/ # Provided by tech-docs gem but has a "broken" link from html-proofer's point of view
+        ],
         :url_swap => { config[:tech_docs][:host] => "" } }).run
   rescue RuntimeError => e
     abort e.to_s


### PR DESCRIPTION
We had previously had this turned off, and we need to add an exemption for the search pages generated by the tech-docs-gem

