### PR TITLE
Add change for sub format

### DIFF
--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -371,7 +371,7 @@ The `id_token` parameter in the response for ‘Make a token request’ contains
 
 ```
 {
-  "sub": "b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
+  "sub": "urn:uuid:b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
   "iss": "https://oidc.integration.account.gov.uk",
   "nonce": "aad0aa969c156b2dfa685f885fac7083",
   "aud": "YOUR_CLIENT_ID",


### PR DESCRIPTION
The `sub` in the ID Token is now prefixed with `urn:uuid:`.
Covered by: https://github.com/alphagov/di-authentication-api/pull/1807

## Why

Verifiable Credentials require identifiers to be URIs, which in this case is the pairwise identifier. Keep things consistent and make pairwises identifiers all have the same prefix.

## What

Updated `sub` in ID Token

## Technical writer support

Not required

## How to review

The [Understand your ID Token](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/integrate-with-code-flow/#understand-your-id-token) section should have the new `sub` format.
