### PR TITLE
AUT-397 - Make change to Sub example

### DIFF
--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -366,7 +366,7 @@ The `id_token` parameter in the response for ‘Make a token request’ contains
 
 ```
 {
-  "sub": "b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
+  "sub": "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=",
   "iss": "https://oidc.integration.account.gov.uk",
   "nonce": "aad0aa969c156b2dfa685f885fac7083",
   "aud": "YOUR_CLIENT_ID",


### PR DESCRIPTION
## Why

- The Sub will now be prefixed with `urn:fdc:gov.uk:2022:` as per RFC 0027 in digital-identity-architecture.
- Make our pairwise identifiers VC compliant by implementing them as a URN as per RFC4198. This would prefix all identifiers with 'urn:fdc:gov.uk:2022:', where 2022 is the DateId and would remain fixed.

## What

 - Make change to Sub example

## Technical writer support

N/A

## How to review

RFC - https://github.com/alphagov/digital-identity-architecture/pull/171