### PR TITLE
Update temporarily unavailable

### DIFF
--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -154,7 +154,7 @@ Location: https://YOUR_REDIRECT_URI?error=invalid_request
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">temporarily_unavailable</span></td>
-    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The GOV.UK Sign In authentication server is temporarily unavailable, which might be caused by temporary overloading or planned maintenance. </span><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Make your authorisation request again in a few minutes.</span></td>
+    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">If you're only making an authentication request (as opposed to requesting both authentication and identity), this error code means the GOV.UK Sign In authentication server is temporarily unavailable, which might be caused by temporary overloading or planned maintenance. </span><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Make your authorisation request again in a few minutes. <br>  <br> If you're making an identity request and you get this error, it means the identity proofing and verification does not currently have capacity for this request.</span></td>
   </tr>
 </tbody>
 </table>

--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -150,7 +150,7 @@ Location: https://YOUR_REDIRECT_URI?error=invalid_request
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">server_error</span></td>
-    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The GOV.UK Sign In authentication server has experienced an internal server error and will return the HTTP status code <code>500</code>.</span></td>
+    <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The GOV.UK Sign In authentication server has experienced an internal server error.</span></td>
   </tr>
   <tr>
     <td class="tg-0pky"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">temporarily_unavailable</span></td>


### PR DESCRIPTION
## Why

Following the conversation on Slack, we need to update the temporarily_unavailable messaging to cover the IPV journey. 

## What

The error message now covers both auth and auth+identity journeys and how they use temporarily_unavailable error message.
