### PR TITLE
Update pages for driving licence claim

### DIFF
--- a/source/integrate-with-integration-environment/choose-which-user-attributes-your-service-can-request.html.md.erb
+++ b/source/integrate-with-integration-environment/choose-which-user-attributes-your-service-can-request.html.md.erb
@@ -141,6 +141,10 @@ You can find details of the claims in the following table.
     <td class="tg-82rs"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000"><code>https://vocab.account.gov.uk/v1/passport</code></span></td>
     <td class="tg-82rs"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">This claim contains your user's passport details if GOV.UK Sign In proved their identity using their passport.</span><br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">If GOV.UK Sign In did not prove your user’s identity using their passport, the authorisation response will not return this claim.</span></td>
   </tr>
+  <tr>
+    <td class="tg-82rs"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000"><code>https://vocab.account.gov.uk/v1/drivingPermit</code></span></td>
+    <td class="tg-82rs"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">This claim contains your user's driving licence details if GOV.UK Sign In proved their identity using their driving licence.</span><br><br><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000">If GOV.UK Sign In did not prove your user’s identity using their driving licence, the authorisation response will not return this claim.</span></td>
+  </tr>
 </tbody>
 </table>
 

--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -77,7 +77,8 @@ After you’ve made an authorisation request for authentication and identity, yo
   "userinfo": {
     "https://vocab.account.gov.uk/v1/coreIdentityJWT": null,
     "https://vocab.account.gov.uk/v1/address": null,
-    "https://vocab.account.gov.uk/v1/passport": null
+    "https://vocab.account.gov.uk/v1/passport": null,
+    "https://vocab.account.gov.uk/v1/drivingPermit": null
   }
 }
 ```

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -51,11 +51,22 @@ Content-Type: application/json
       "addressCountry": "GB",
       "validUntil": "2022-01-01"
     }
+  ]
+},
+  "https://vocab.account.gov.uk/v1/drivingPermit": [
+    {
+      "expiryDate": "2023-01-18",
+      "issueNumber": "5",
+      "issuedBy": "DVLA",
+      "fullAddress": "122 BURNS CRESCENT EDINBURGH EH1 9GP",
+      "personalNumber": "DOE99802085J99FG",
+      "issueDate": "2010-01-18"
+}
   ],
   "https://vocab.account.gov.uk/v1/passport": [
      {
         "documentNumber": "1223456",
-        "expiryDate": "2022-02-02"
+        "expiryDate": "2032-02-02"
       }
     ]
 }
@@ -281,6 +292,32 @@ The <code>https://vocab.account.gov.uk/v1/passport</code> claim contains the det
   <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>expiryDate</code></span></td>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The expiration date as an <a href=https://schema.org/Date><span>ISO 8601 date</span></a> string.</span></td>
+  </tr>
+</tbody>
+</table>
+
+## Understand your user's driving licence claim
+The <code>https://vocab.account.gov.uk/v1/drivingPermit</code> claim contains the details of your user’s driving licence, if they submitted one when proving their identity.
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Property</span></th>
+    <th class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Definition</span></th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>personalNumber</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The licence number.</span></td>
+  </tr>
+  <tr>
+  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>fullAddress</code></span></td>
+  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The user's full address as a text string, including address lines and postcode.</span></td>
+</tr>
+  <tr>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issueNumber</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The last 2 characters of the <code>personalNumber</code>. You will only receive this property for licences issued by the Driver and Vehicle Licensing Agency (DVLA).</span></td>
   </tr>
 </tbody>
 </table>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -308,16 +308,28 @@ The <code>https://vocab.account.gov.uk/v1/drivingPermit</code> claim contains th
 </thead>
 <tbody>
   <tr>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>personalNumber</code></span></td>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The licence number.</span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>expiryDate</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The expiry date of the driving licence.</span></td>
+  </tr>
+  <tr>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issueNumber</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The last 2 characters of the <code>personalNumber</code>. You will only receive this property for licences issued by the Driver and Vehicle Licensing Agency (DVLA).</span></td>
+  </tr>
+  <tr>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issuedBy</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The organisation that issued the driving licence.</span></td>
   </tr>
   <tr>
   <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>fullAddress</code></span></td>
   <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The user's full address as a text string, including address lines and postcode.</span></td>
 </tr>
   <tr>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issueNumber</code></span></td>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The last 2 characters of the <code>personalNumber</code>. You will only receive this property for licences issued by the Driver and Vehicle Licensing Agency (DVLA).</span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>personalNumber</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The licence number of the driving licence.</span></td>
+  </tr>
+  <tr>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issueDate</code></span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The date the licence was issued.</span></td>
   </tr>
 </tbody>
 </table>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -307,7 +307,7 @@ The <code>https://vocab.account.gov.uk/v1/drivingPermit</code> claim contains th
 <tbody>
   <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>expiryDate</code></span></td>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The expiry date of the driving licence.</span></td>
+    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The expiry date of the driving licence as an <a href=https://schema.org/Date><span>ISO 8601 date</span></a> string.</span></td>
   </tr>
   <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issueNumber</code></span></td>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -58,9 +58,7 @@ Content-Type: application/json
       "expiryDate": "2023-01-18",
       "issueNumber": "5",
       "issuedBy": "DVLA",
-      "fullAddress": "122 BURNS CRESCENT EDINBURGH EH1 9GP",
       "personalNumber": "DOE99802085J99FG",
-      "issueDate": "2010-01-18"
 }
   ],
   "https://vocab.account.gov.uk/v1/passport": [
@@ -320,16 +318,8 @@ The <code>https://vocab.account.gov.uk/v1/drivingPermit</code> claim contains th
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The organisation that issued the driving licence.</span></td>
   </tr>
   <tr>
-  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>fullAddress</code></span></td>
-  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The user's full address as a text string, including address lines and postcode.</span></td>
-</tr>
-  <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>personalNumber</code></span></td>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The licence number of the driving licence.</span></td>
-  </tr>
-  <tr>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>issueDate</code></span></td>
-    <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The date the licence was issued.</span></td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Why

We can now provide a driving licence claim to service teams. 

## What

This updates all the relevant pages and sections where we need to include the driving licence claim. 

## Technical writer support

Pre-i and 2i needed.

## How to review

Check for consistency with other sections in the documentation (for example, the claims table where the new entry is).
