### PR TITLE
Add passport issuer information

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -21,7 +21,8 @@ after_build do |builder|
             /search/ # Provided by tech-docs gem but has a "broken" link from html-proofer's point of view
         ],
         :url_ignore => [
-            /#{Regexp.quote(config[:tech_docs][:github_repo])}/ # Avoid chicken-and-egg problem when new pages in a PR break the link checker
+            /#{Regexp.quote(config[:tech_docs][:github_repo])}/, # Avoid chicken-and-egg problem when new pages in a PR break the link checker
+            "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/data-protection-impact-assessments-dpias", # Avoid flagging checker because of CloudFlare security on site
         ],
         :url_swap => { config[:tech_docs][:host] => "" },
         typhoeus: {

--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ after_build do |builder|
         ],
         :url_ignore => [
             /#{Regexp.quote(config[:tech_docs][:github_repo])}/, # Avoid chicken-and-egg problem when new pages in a PR break the link checker
-            "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/data-protection-impact-assessments-dpias", # Avoid flagging checker because of CloudFlare security on site
+            "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/data-protection-impact-assessments-dpias" # Avoid flagging checker because of CloudFlare security on site
         ],
         :url_swap => { config[:tech_docs][:host] => "" },
         typhoeus: {

--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ after_build do |builder|
         ],
         :url_ignore => [
             /#{Regexp.quote(config[:tech_docs][:github_repo])}/, # Avoid chicken-and-egg problem when new pages in a PR break the link checker
-            "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/data-protection-impact-assessments-dpias" # Avoid flagging checker because of CloudFlare security on site
+            [/ico.org.uk/] # Avoid flagging checker because of CloudFlare security on site
         ],
         :url_swap => { config[:tech_docs][:host] => "" },
         typhoeus: {

--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ after_build do |builder|
         ],
         :url_ignore => [
             /#{Regexp.quote(config[:tech_docs][:github_repo])}/, # Avoid chicken-and-egg problem when new pages in a PR break the link checker
-            "https://ico.org.uk/" # Avoid flagging checker because of CloudFlare security on site
+            "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/data-protection-impact-assessments-dpias/" # Avoid flagging checker because of CloudFlare security on site
         ],
         :url_swap => { config[:tech_docs][:host] => "" },
         typhoeus: {

--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ after_build do |builder|
         ],
         :url_ignore => [
             /#{Regexp.quote(config[:tech_docs][:github_repo])}/, # Avoid chicken-and-egg problem when new pages in a PR break the link checker
-            [/ico.org.uk/] # Avoid flagging checker because of CloudFlare security on site
+            "https://ico.org.uk/" # Avoid flagging checker because of CloudFlare security on site
         ],
         :url_swap => { config[:tech_docs][:host] => "" },
         typhoeus: {

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -290,7 +290,7 @@ The <code>https://vocab.account.gov.uk/v1/passport</code> claim contains the det
   </tr>
   <tr>
   <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>icaoIssuerCode</code></span></td>
-  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"></span>An identifier for a passport's issuing state or organisation. This is defined by the International Civil Aviation Organization (ICAO) standard <a href="https://www.icao.int/publications/Documents/9303_p3_cons_en.pdf">9303 Machine Readable Travel Documents</a>. The identifier is up to 3 characters.</td>
+  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"></span>An identifier for the state or organisation that issued the passport. This is defined by the International Civil Aviation Organization (ICAO) standard <a href="https://www.icao.int/publications/Documents/9303_p3_cons_en.pdf">9303 Machine Readable Travel Documents</a>. The identifier is up to 3 characters.</td>
   </tr>
   <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>expiryDate</code></span></td>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Process your user’s identity information
 weight: 5.6
-last_reviewed_on: 2021-06-27
+last_reviewed_on: 2023-01-20
 review_in: 6 months
 ---
 
@@ -64,6 +64,7 @@ Content-Type: application/json
   "https://vocab.account.gov.uk/v1/passport": [
      {
         "documentNumber": "1223456",
+        "icaoIssuerCode": "GBR",
         "expiryDate": "2032-02-02"
       }
     ]
@@ -286,6 +287,10 @@ The <code>https://vocab.account.gov.uk/v1/passport</code> claim contains the det
   <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>documentNumber</code></span></td>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">The passport number.</span></td>
+  </tr>
+  <tr>
+  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>icaoIssuerCode</code></span></td>
+  <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"></span>An identifier for a passport's issuing state or organisation. This is defined by the International Civil Aviation Organization (ICAO) standard <a href="https://www.icao.int/publications/Documents/9303_p3_cons_en.pdf">9303 Machine Readable Travel Documents</a>. The identifier is up to 3 characters.</td>
   </tr>
   <tr>
     <td class="tg-0lax"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>expiryDate</code></span></td>


### PR DESCRIPTION
## Why

We need to update the documentation for the [new property of the passport claim](https://govukverify.atlassian.net/browse/LIME-255). 

## What

Add the new property to the passport claim table and update the sample `/userinfo` response.

## Technical writer support

Review in progress.

## How to review
Check for consistency with other sections.
