### PR TITLE
Draft note clarifying sub-building-name field

### DIFF
--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -230,7 +230,10 @@ Each JSON object in the list may contain any of the following properties:
   </tr>
   <tr>
     <td class="tg-ktyi"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>subBuildingName</code></span></td>
-    <td class="tg-ktyi"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Maps to <code>SUB_BUILDING_NAME</code> in the </span><a href=https://www.royalmail.com/find-a-postcode><span>Postcode Address File</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"> and </span><a href="https://apidocs.os.uk/docs/os-places-dpa-output"><span>Ordnance Survey Places API</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">. </span><br></td>
+    <td class="tg-ktyi">
+      <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Maps to <code>SUB_BUILDING_NAME</code> in the </span><a href="https://www.royalmail.com/find-a-postcode"><span>Postcode Address File</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"> and </span><a href="https://apidocs.os.uk/docs/os-places-dpa-output"><span>Ordnance Survey Places API</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">. </span><br>
+      <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">May be used in conjunction with either <code>buildingName</code> or <code>buildingNumber</code>.</span>
+    </td>
   </tr>
   <tr>
     <td class="tg-ktyi"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>buildingNumber</code></span></td>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -232,7 +232,7 @@ Each JSON object in the list may contain any of the following properties:
     <td class="tg-ktyi"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>subBuildingName</code></span></td>
     <td class="tg-ktyi">
       <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Maps to <code>SUB_BUILDING_NAME</code> in the </span><a href="https://www.royalmail.com/find-a-postcode"><span>Postcode Address File</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"> and </span><a href="https://apidocs.os.uk/docs/os-places-dpa-output"><span>Ordnance Survey Places API</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">. </span><br>
-      <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">May be used in conjunction with either <code>buildingName</code> or <code>buildingNumber</code>.</span>
+      <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">You can use <code>SUB_BUILDING_NAME</code> with either <code>buildingName</code> or <code>buildingNumber</code>.</span>
     </td>
   </tr>
   <tr>

--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -232,7 +232,7 @@ Each JSON object in the list may contain any of the following properties:
     <td class="tg-ktyi"><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>subBuildingName</code></span></td>
     <td class="tg-ktyi">
       <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">Maps to <code>SUB_BUILDING_NAME</code> in the </span><a href="https://www.royalmail.com/find-a-postcode"><span>Postcode Address File</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"> and </span><a href="https://apidocs.os.uk/docs/os-places-dpa-output"><span>Ordnance Survey Places API</span></a><span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">. </span><br>
-      <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent">You can use <code>SUB_BUILDING_NAME</code> with either <code>buildingName</code> or <code>buildingNumber</code>.</span>
+      <span style="font-weight:400;font-style:normal;text-decoration:none;color:#000;background-color:transparent"><code>subBuildingName</code> may accompany either <code>buildingName</code> or <code>buildingNumber</code>.</span>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
This suggested documentation change is in response to some confusion that arose in a relying party team, quote

> Thanks for your email and sending the offending address in the format we can use for debugging. I confirm that this is an issue as described by the user and the "Apartment M" being dropped.
> The reason for that is, our parsing routine assumes that if "buildingName" is empty then there's no reason for a value expected in "subBuildingName". 
> I understand that this might be impossible to tell but was this a wrong assumption ? or is this an odd address occurrence ?

Opening this as a draft as I don't have a local running copy of these docs, and the strange formatting / spans etc make it a bit difficult to be sure that I'm suggesting the right thing!