### PR TITLE
BAU: Fix Userinfo phone claim names

### DIFF
--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -660,8 +660,8 @@ Content-Type: application/json
   "sub": "b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
   "email": "test@example.com",
   "email_verified": true,
-  "phone": "01406946277",
-  "phone_verified": true,
+  "phone_number": "01406946277",
+  "phone_number_verified": true,
   "updated_at":1311280970
 }
 ```


### PR DESCRIPTION
## Why
- The phone claims in the docs were called `phone` and `phone_verified`, but in reality the API returns `phone_number` and `phone_number_verified` (the API response is as per OIDC spec; it is the docs which are divergent)

## What
- Change claim names in example Userinfo response.

## Technical writer support
- Yes

## How to review
- Confirm that this is not a problem to change; it seems to me to be a straightforward error
