### PR TITLE
BAU: Remove reference to possible absence of core identity JWT

### DIFF
--- a/source/integrate-with-integration-environment/process-identity-information.html.md.erb
+++ b/source/integrate-with-integration-environment/process-identity-information.html.md.erb
@@ -79,8 +79,6 @@ The following are core identity attributes:
 * your user’s date of birth
 * the level of identity confidence GOV.UK One Login has reached
 
-<%= warning_text("If the <code>https://vocab.account.gov.uk/v1/coreIdentityJWT</code> property is not present, then GOV.UK One Login was not able to prove your user's identity.") %>
-
 Our support team will give you the public key you must use to validate this JWT. We recommend you [use a certified JWT/JWS implementation](https://openid.net/developers/jwt/).
 
 The JWT contains the following claims:


### PR DESCRIPTION
## Why
- This can never happen in a P2 journey at the moment, as if identity is not proven, then the RP gets an access_denied error
- This means that they do not have a code/token to use to make a userinfo request in the first place
- It is therefore misleading to suggest that a userinfo response is possible without the core identity JWT in a P2 journey

## What
- Remove reference to possible absence of core identity JWT

## Technical writer support
- Yes; would appreciate @elenaschwan review in particular please

## How to review
- Confirm that the removal of this wording is not problematic for the wider context
- Confirm that you agree the wording was misleading and that removal is the best thing to do as opposed to rephrasing
