### PR TITLE
Add warning message to all relevant code samples

### DIFF
--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -50,7 +50,7 @@ HTTP/1.1
 Host: oidc.integration.account.gov.uk
 ```
 
-<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersand (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 ### Make an authorisation request for authentication and identity
 If you need identity assurance as well as authentication, use this example message to make a `GET` request.
@@ -72,7 +72,7 @@ HTTP/1.1
 Host: oidc.integration.account.gov.uk
 ```
 
-<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersand (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 #### Create a URL-encoded JSON object for `<claims-request>`
 
@@ -333,7 +333,7 @@ grant_type=authorization_code
 OiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI
 ```
 
-<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersand (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 <table class="tg">
 <thead>
@@ -573,7 +573,7 @@ grant_type=refresh_token
 &refresh_token=i6mapTIAVSp2oJkgUnCACKKfZxt_H5MBLiqcybBBd04
 ```
 
-<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersand (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 #### Receive response for ‘Make a refresh token request’
 

--- a/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
+++ b/source/integrate-with-integration-environment/integrate-with-code-flow.html.md.erb
@@ -50,6 +50,8 @@ HTTP/1.1
 Host: oidc.integration.account.gov.uk
 ```
 
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+
 ### Make an authorisation request for authentication and identity
 If you need identity assurance as well as authentication, use this example message to make a `GET` request.
 
@@ -69,6 +71,8 @@ GET /authorize?response_type=code
 HTTP/1.1
 Host: oidc.integration.account.gov.uk
 ```
+
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 #### Create a URL-encoded JSON object for `<claims-request>`
 
@@ -329,6 +333,8 @@ grant_type=authorization_code
 OiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI
 ```
 
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+
 <table class="tg">
 <thead>
   <tr>
@@ -566,6 +572,8 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=refresh_token
 &refresh_token=i6mapTIAVSp2oJkgUnCACKKfZxt_H5MBLiqcybBBd04
 ```
+
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 #### Receive response for ‘Make a refresh token request’
 

--- a/source/integrate-with-integration-environment/log-your-users-out.html.md.erb
+++ b/source/integrate-with-integration-environment/log-your-users-out.html.md.erb
@@ -20,7 +20,7 @@ You must set up the functionality to log your users out of a GOV.UK One Login se
     &state=sadk8d4--lda%d
     ```
 
-<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersand (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
 
 If no GOV.UK One Login session exists, for example if the session has expired, the endpoint redirects your user to the default logout page for GOV.UK One Login. Your user can continue their journey from the default logout page.
 

--- a/source/integrate-with-integration-environment/log-your-users-out.html.md.erb
+++ b/source/integrate-with-integration-environment/log-your-users-out.html.md.erb
@@ -20,6 +20,8 @@ You must set up the functionality to log your users out of a GOV.UK One Login se
     &state=sadk8d4--lda%d
     ```
 
+<%= warning_text('This code example uses formatting that makes it easier to read. If you copy the example, you must make sure the request is:<ul><li>a continuous line of text separating each parameter with an ampersands (&)</li><li>not split across multiple lines</li><li>without any additional separators such as newline, commas or tabs</li></ul>') %>
+
 If no GOV.UK One Login session exists, for example if the session has expired, the endpoint redirects your user to the default logout page for GOV.UK One Login. Your user can continue their journey from the default logout page.
 
 


### PR DESCRIPTION
(also captured in https://govukverify.atlassian.net/browse/AUT-1380?atlOrigin=eyJpIjoiOTRhOGVlOGQ1NmMyNGQ3ZTkwM2MzOTExN2Q3NWQzZDMiLCJwIjoiaiJ9)

## Why

An HMRC colleague was setting up integration with One Login and used our documentation as a reference. His initial request looked like this:

```
POST https://oidc.integration.account.gov.uk/token
Content-Type: application/x-www-form-urlencoded

grant_type=authorization_code
&code=WJETRuY2Tw9Gp3WIhK13vZFedmTiF3S01DPnrzxZIUc
&redirect_uri=https%3A%2F%2Fwww.qa.tax.service.gov.uk%2Fone-login-gateway%2Fcontinue
&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
&client_assertion=eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJfb2ZTMFpIVWt3b2haVDc5Z2Z1cENES1U3TzgiLCJhdWQiOiJodHRwczovL29pZGMuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsvdG9rZW4iLCJpc3MiOiJfb2ZTMFpIVWt3b2haVDc5Z2Z1cENES1U3TzgiLCJleHAiOjE2ODg0Nzg3NTgsImlhdCI6MTY4ODQ3NzU1OCwianRpIjoiY2RhMzA5Y2YtNjA2Yi00N2UzLWJlOWMtYmY2MWIzZDRiZGQ4In0.M1_V2DiqpfWR9ZqErF7oL3n04o5Ax8ikatH9Rk4ZBthc6_nQM3fv5r1vawpnbPooMnIqow7vMXism3BuBESbNyvnxXD-ucpfr5LOwRw_iBSEwA4Lb0ntKwPkfKLvf5c5sInmAvEeqhdChhZp2oQzWwQZpGYRgTIBWweL8nU4XHj-0mPENOLd4X_-t4bGxCdLPMNM2sPd1VbtQtn9YhM3dfDc5Yoh-ZSw8fqntgsMlBSwr84yMONOJHHsEw36Tc5nT9LjW-xc17A54PgcZGwXgb2XyrtkxCT_i0auz0Ri5U95Io3WvwtCucLViwr3VijqM5zyQxPSEY1IY7mp5-2jZQ
```

The response was:

```
https://oidc.integration.account.gov.uk/token

HTTP/1.1 400 Bad Request
Date: Tue, 04 Jul 2023 13:32:56 GMT
Content-Type: application/json
Content-Length: 73
Connection: keep-alive
x-amzn-RequestId: 18134abe-8b0e-4d5b-ae01-10edf67f80bd
X-XSS-Protection: 1; mode=block
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Frame-Options: DENY
Content-Security-Policy: frame-ancestors 'none'
x-amz-apigw-id: HindbHLzLPEFoQw=
Cache-Control: no-cache, no-store
X-Content-Type-Options: nosniff
X-Amzn-Trace-Id: Root=1-64a41f88-4b5bafb767022dd64c6a5bd8
Pragma: no-cache

{
  "error_description": "Invalid private_key_jwt",
  "error": "invalid_request"
}

``` 

This was not particularly descriptive as to the issue, which was in fact that he had split the body across lines (one line per param) which meant there were newline characters in the body.

He rectified this later, sending single-line request that fixed the issue. 

## What

We will add a message after each affected cope sample to explain the issue and make the user aware on how to modify it manually.

## Technical writer support

This will be pre-i'ed and 2i'ed.

